### PR TITLE
SVCPLAN-9045/SVCPLAN-9125: custom certs, optional dependencies, fix n…

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,9 @@
 ---
+profile_ondemand::custom_certificates: {}
+
+# Jake: The below params probably aren't doing anything.
+#       I believe that data for one module inside of another
+#       is ignored by lookups.
 letsencrypt::renew_additional_args:
   - "--standalone"
 letsencrypt::renew_pre_hook_commands:

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -2,8 +2,8 @@
 version: 5
 
 defaults:  # Used for any hierarchy level that omits these keys.
-  datadir: data         # This path is relative to hiera.yaml's directory.
-  data_hash: yaml_data  # Use the built-in YAML backend.
+  datadir: "data"         # This path is relative to hiera.yaml's directory.
+  data_hash: "yaml_data"  # Use the built-in YAML backend.
 
 hierarchy:
   - name: "osfamily/major release"
@@ -17,5 +17,5 @@ hierarchy:
     paths:
       - "os/%{facts.os.name}.yaml"
       - "os/%{facts.os.family}.yaml"
-  - name: 'common'
-    path: 'common.yaml'
+  - name: "common"
+    path: "common.yaml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,10 +1,17 @@
 # @summary Main class for profile_ondemand
 #
+# @param custom_certificates
+#   Optionally provide custom parameters for certificate(s) to
+#   be created. If this is not provided a cert will be created
+#   using the FQDN of the host.
+#
 # @param nodejs_version
-#   The Node.js version to use for dependency
+#   The Node.js version to use for dependency. Leave unset/null
+#   to NOT enable the DNF module nodejs:<nodejs_version>.
 #
 # @param ruby_version
-#   The Ruby version to use for dependency
+#   The Ruby version to use for dependency. Leave unset/null
+#   to NOT enable the DNF module nodejs:<nodejs_version>.
 #
 # @param crons
 #   Hash of cron jobs to set up
@@ -19,11 +26,12 @@
 # @example
 #   include profile_ondemand
 class profile_ondemand (
-  String $nodejs_version,
-  String $ruby_version,
-  Hash $crons,
-  Boolean $enable_xdmod_export = false,
-  Boolean $enable_dynamic_widgets = true,
+  Hash             $custom_certificates,
+  Optional[String] $nodejs_version,
+  Optional[String] $ruby_version,
+  Hash             $crons,
+  Boolean          $enable_xdmod_export = false,
+  Boolean          $enable_dynamic_widgets = true,
 ) {
   include apache::mod::rewrite
   include apache::mod::env
@@ -43,22 +51,28 @@ class profile_ondemand (
   if $enable_dynamic_widgets {
     file { '/etc/ood/config/ondemand.d/dynamic-widgets.yml':
       ensure  => 'file',
-      content => "bc_dynamic_js: true",
+      content => 'bc_dynamic_js: true',
     }
   }
 
-  package { 'nodejs':
-    ensure      => $nodejs_version,
-    enable_only => true,
-    provider    => 'dnfmodule',
-    before      => Class['openondemand'],
+  # make management of nodejs "package" (actually DNF module) optional
+  if ( $nodejs_version) {
+    package { 'nodejs':
+      ensure      => $nodejs_version,
+      enable_only => true,
+      provider    => 'dnfmodule',
+      before      => Class['openondemand'],
+    }
   }
 
-  package { 'ruby':
-    ensure      => $ruby_version,
-    enable_only => true,
-    provider    => 'dnfmodule',
-    before      => Class['openondemand'],
+  # make management of ruby "package" (actually DNF module) optional
+  if ( $ruby_version) {
+    package { 'ruby':
+      ensure      => $ruby_version,
+      enable_only => true,
+      provider    => 'dnfmodule',
+      before      => Class['openondemand'],
+    }
   }
 
   file { '/etc/ood/config/ood-portal.conf':
@@ -87,11 +101,17 @@ class profile_ondemand (
     cron { $k: * => $v }
   }
 
-  letsencrypt::certonly { $facts['networking']['fqdn']:
-    plugin  => 'standalone',
-    require => [
-      Package['httpd'],
-      Class['openondemand'],
-    ],
+  if !empty($custom_certificates) {
+    $custom_certificates.each |$certificate, $properties| {
+      letsencrypt::certonly { $certificate: * => $properties }
+    }
+  } else {
+    letsencrypt::certonly { $facts['networking']['fqdn']:
+      plugin  => 'standalone',
+      require => [
+        Package['httpd'],
+        Class['openondemand'],
+      ],
+    }
   }
 }

--- a/manifests/navbar.pp
+++ b/manifests/navbar.pp
@@ -11,8 +11,8 @@
 #
 class profile_ondemand::navbar (
   Boolean $include_default = true,
-  Optional[Array[Hash]] $navbar_items = undef,
-  Optional[Array[Hash]] $helpbar_items = undef,
+  Optional[Array] $navbar_items = undef,
+  Optional[Array] $helpbar_items = undef,
 ) {
   if $include_default {
     $_content = {


### PR DESCRIPTION
…avbar customization

SVCPLAN-9045:

allow customization of Let's Encrypt certs, e.g., SAN certificates

SVCPLAN-9125:

Make ruby_version and nodejs_version optional. If not set, do not manage DNF modules with those versions. (Assumed RPMs named nodejs and ruby will be installed or available via some other repo.)

Fix navbar and helpbar customization (don't force Array[Hash] because if we want to re-add select default items they will be Strings, not Hashes).